### PR TITLE
Refactor, and set margins using stylesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ compile_commands.json
 /KoboRoot.tgz
 /libnickelclock.so
 /src/nickelclock.o
+/src/nickelclock.moc
+/src/nickelclock.moc.o

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include libs/NickelHook/NickelHook.mk
 
 override LIBRARY  := libnickelclock.so
 override SOURCES  += src/nickelclock.cc 
+override MOCS     += src/nickelclock.h
 override CFLAGS   += -Wall -Wextra -Werror
 override CXXFLAGS += -Wall -Wextra -Werror -Wno-missing-field-initializers
 

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -189,11 +189,7 @@ void NC::addTimeToFooter(ReadingFooter *rf, TimePos position)
             nh_log("Adding TimeLabel widget to ReadingView header");
 
             // Set margins
-            QMargins margin = hl->contentsMargins();
-            int newMargin = settings.hMargin();
-            if (newMargin < 0)
-                newMargin = margin.left() / 10;
-            hl->setContentsMargins(newMargin, margin.top(), newMargin, margin.bottom());
+            updateFooterMargins(hl);
 
             hl->setStretch(0, 2);
 
@@ -214,6 +210,22 @@ void NC::addTimeToFooter(ReadingFooter *rf, TimePos position)
         }
     }
 }
+
+// Update the margins of the ReadingFooter layout if required.
+void NC::updateFooterMargins(QLayout *layout)
+{
+    if (!layout)
+        return;
+    QMargins margin = layout->contentsMargins();
+    if (origFooterMargin < 0)
+        origFooterMargin = margin.left();
+    int newMargin = settings.hMargin();
+    if (newMargin < 0)
+        newMargin = origFooterMargin / 10;
+    if (newMargin != margin.left())
+        layout->setContentsMargins(newMargin, margin.top(), newMargin, margin.bottom());
+}
+
 
 // On recent 4.x firmware versions, the header and footer are setup in 
 // Ui_ReadingView::setupUi(). They are ReadingFooter widgets, with names set to 

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -1,0 +1,57 @@
+#ifndef NICKELCLOCK_H
+#define NICKELCLOCK_H
+
+#include <QObject>
+#include <QWidget>
+#include <QLabel>
+#include <QString>
+#include <QSettings>
+
+typedef QWidget ReadingView;
+typedef QWidget ReadingFooter;
+typedef QLabel TimeLabel;
+typedef QLabel TouchLabel;
+
+enum class TimePos {Left, Right};
+enum class TimePlacement {Header, Footer};
+
+#ifndef NICKEL_CLOCK_DIR
+    #define NICKEL_CLOCK_DIR "/mnt/onboard/.adds/nickelclock"
+#endif
+
+class NCSettings 
+{
+    public:
+        NCSettings(QRect const& screenGeom);
+        
+        TimePlacement placement();
+        TimePos position();
+        int hMargin();
+    private:
+        QSettings settings;
+        QString placeKey = "placement";
+        QString posKey = "position";
+        QString marginKey = "hor_margin";
+        QString placeHeader = "header";
+        QString placeFooter = "footer";
+        QString posLeft = "left";
+        QString posRight = "right";
+        QString marginAuto = "auto";
+
+        int maxHMargin = 200;
+
+        void syncSettings();
+        void setMaxHMargin(QRect const& screenGeom);
+};
+
+class NC : public QObject
+{
+    Q_OBJECT
+    public:
+        NCSettings settings;
+        
+        NC(QRect const& screenGeom);
+        void addTimeToFooter(ReadingFooter *rf, TimePos position);
+};
+
+#endif

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -52,6 +52,9 @@ class NC : public QObject
         
         NC(QRect const& screenGeom);
         void addTimeToFooter(ReadingFooter *rf, TimePos position);
+    private:
+        int origFooterMargin = -1;
+        void updateFooterMargins(QLayout *layout);
 };
 
 #endif

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QWidget>
 #include <QLabel>
+#include <QRegularExpression>
 #include <QString>
 #include <QSettings>
 
@@ -52,9 +53,16 @@ class NC : public QObject
         
         NC(QRect const& screenGeom);
         void addTimeToFooter(ReadingFooter *rf, TimePos position);
+        void setFooterStylesheet(ReadingFooter *rf);
+        QString const& timeLabelStylesheet();
     private:
         int origFooterMargin = -1;
+        QString origFooterStylesheet;
+        QString tlStylesheet;
+        QRegularExpression footerMarginRe;
         void updateFooterMargins(QLayout *layout);
+        void getFooterStylesheet();
+        void createTimeLabelStylesheet();
 };
 
 #endif


### PR DESCRIPTION
This PR refactors most of the code into a QObject derived class. This allows for interaction with Qt signals, slots and events.

`ReadingFooter` margins are now set by replacing the original stylesheet, instead of programmatically setting them. This should fix #2 although it's arguably a bit uglier. There should be less corner cases using this method however.

@pgaskin do you think this is a better approach compared to the previous PR?