### PR TITLE
Battery indicator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ compile_commands.json
 /KoboRoot.tgz
 /libnickelclock.so
 /src/nickelclock.o
+/src/nc_settings.o
 /src/nickelclock.moc
 /src/nickelclock.moc.o

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include libs/NickelHook/NickelHook.mk
 
 override LIBRARY  := libnickelclock.so
-override SOURCES  += src/nickelclock.cc 
+override SOURCES  += src/nickelclock.cc src/nc_settings.cc 
 override MOCS     += src/nickelclock.h
 override CFLAGS   += -Wall -Wextra -Werror
 override CXXFLAGS += -Wall -Wextra -Werror -Wno-missing-field-initializers

--- a/README.md
+++ b/README.md
@@ -30,40 +30,63 @@ and [NanoClock](https://github.com/NiLuJe/NanoClock).
 
 ## Configure NickelCLock
 
-The clock may be displayed in one of four locations on the screen. They are:
+The clock and battery may be positioned independently in one of four locations: 
 
-- Header
-    - left
-    - right
-- footer
-    - left
-    - right
+**Left header**, **Right header**, **Left footer**, **Right footer**
 
-You can set this location in `.adds/nickelclock/settings.ini`. The default 
-settings file contains:
+Positioning and other settings are saved in `.adds/nickelclock/settings.ini`, 
+and the default settings file is as follows:
 
 ```ini
 [General]
-hor_margin=auto
-placement=header
-position=right
+Margin=Auto
+WidgetOrder=ClockFirst
+
+[Battery]
+BatteryType=Level
+Enabled=false
+Placement=Header
+Position=Right
+
+[Clock]
+Enabled=true
+Placement=Header
+Position=Right
+
 ```
+The following settings may be set. **Note that entries are case sensitive**:
 
-The allowed values for `placement` are:
-- `header`
-- `footer`
+The allowed values for `Margin` in `[General]` are:
+- `Auto`
+- Any whole number greater than zero, up to a quarter of your screen width.
 
-The allowed values for `position` are:
-- `left`
-- `right`
+The allowed values for `Placement` in `[Clock]` and `[Battery]` are:
+- `Header`
+- `Footer`
 
-`hor_margin` can be set to `auto` for an automatic margin, or any whole number 
-value above zero, up to a quarter of your screen width. 
-The default value is `auto`.
+The allowed values for `Position` in `[Clock]` and `[Battery]` are:
+- `Left`
+- `Right`
+
+The allowed values for `Enabled` in `[Clock]` and `[Battery]` are:
+- `true`
+- `false`
+
+The allowed values for `BatteryType` in `[Battery]` are:
+- `Level`
+- `Icon`
+- `Both`
+
+If both the clock and the battery level are set to the same position, the 
+setting `WidgetOrder` in `[General]` determines their display order. The 
+allowed values are:
+- `ClockFirst`
+- `BatteryFirst`
 
 No other customisation is available at this time.
 
-If you have disabled your header and/or footer, the clock may not show.
+If you have disabled the header and/or footer in the reading settings, the 
+clock or battery may not show.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ and the default settings file is as follows:
 ```ini
 [General]
 Margin=Auto
-WidgetOrder=ClockFirst
 
 [Battery]
 BatteryType=Level
@@ -77,11 +76,10 @@ The allowed values for `BatteryType` in `[Battery]` are:
 - `Icon`
 - `Both`
 
-If both the clock and the battery level are set to the same position, the 
-setting `WidgetOrder` in `[General]` determines their display order. The 
-allowed values are:
-- `ClockFirst`
-- `BatteryFirst`
+The battery icon is not compatible with dark mode, the icon is not inverted.
+
+Setting both clock and battery level to the same placement and position is 
+not supported, and the result will be neither showing.
 
 No other customisation is available at this time.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ BatteryType=Level
 Enabled=false
 Placement=Header
 Position=Right
+LevelTemplate=%1%
 
 [Clock]
 Enabled=true
@@ -55,29 +56,26 @@ Position=Right
 ```
 The following settings may be set. **Note that entries are case sensitive**:
 
-The allowed values for `Margin` in `[General]` are:
-- `Auto`
-- Any whole number greater than zero, up to a quarter of your screen width.
+### [General] settings
 
-The allowed values for `Placement` in `[Clock]` and `[Battery]` are:
-- `Header`
-- `Footer`
+|Setting|Values|
+|-------|------|
+|`Margin`|`Auto`, or any whole number greater than zero, up to a quarter of your screen width.|
 
-The allowed values for `Position` in `[Clock]` and `[Battery]` are:
-- `Left`
-- `Right`
+### [Clock] and [Battery] settings
 
-The allowed values for `Enabled` in `[Clock]` and `[Battery]` are:
-- `true`
-- `false`
+|Setting|Values|
+|-------|------|
+|`Placement`|`Header`, `Footer`|
+|`Position` |`Left`, `Right`|
+|`Enabled`  |`true`, `false`|
 
-The allowed values for `BatteryType` in `[Battery]` are:
-- `Level`
-- `Icon`
-- `Both`
+### [Battery] settings
 
-The allowed value for `LevelTemplate` in `[Battery]` is any string that contains 
-the sequence `%1`. The default value is `%1%`, which corresponds to `100%`.
+|Setting|Values|
+|-------|------|
+|`BatteryType`|`Level`, `Icon`, `Both`|
+|`LevelTemplate`|Any string that contains `%1`|
 
 The battery icon is not compatible with dark mode, the icon is not inverted.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The allowed values for `BatteryType` in `[Battery]` are:
 - `Icon`
 - `Both`
 
+The allowed value for `LevelTemplate` in `[Battery]` is any string that contains 
+the sequence `%1`. The default value is `%1%`, which corresponds to `100%`.
+
 The battery icon is not compatible with dark mode, the icon is not inverted.
 
 Setting both clock and battery level to the same placement and position is 

--- a/src/nc_common.h
+++ b/src/nc_common.h
@@ -8,7 +8,6 @@
 enum Position { Left, Right };
 enum Placement { Header, Footer };
 enum Widget { Clock, Battery };
-enum WidgetOrder { ClockFirst, BatteryFirst };
 enum BatteryType { Level, Icon, Both };
 enum Margin { Auto = -1 };
 

--- a/src/nc_common.h
+++ b/src/nc_common.h
@@ -1,0 +1,15 @@
+#ifndef NC_COMMON_H
+#define NC_COMMON_H
+
+#ifndef NICKEL_CLOCK_DIR
+    #define NICKEL_CLOCK_DIR "/mnt/onboard/.adds/nickelclock"
+#endif
+  
+enum Position { Left, Right };
+enum Placement { Header, Footer };
+enum Widget { Clock, Battery };
+enum WidgetOrder { ClockFirst, BatteryFirst };
+enum BatteryType { Level, Icon, Both };
+enum Margin { Auto = -1 };
+
+#endif // NC_COMMON_H

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -1,0 +1,99 @@
+#include "nc_common.h"
+#include "nc_settings.h"
+
+NCSettings::NCSettings(QRect const& screenGeom)
+    : settings(NICKEL_CLOCK_DIR "/settings.ini", QSettings::IniFormat)
+{
+    setMaxHMargin(screenGeom);
+    syncSettings();
+}
+
+void NCSettings::syncSettings()
+{
+    settings.sync();
+
+    QString const groups[] = {SL(Clock), SL(Battery)};
+    for (auto& g : groups) {
+        settings.beginGroup(g);
+
+        QVariant enabled = settings.value(enabledKey);
+        if (enabled.isNull())
+            enabled = g == SL(Clock) ? true : false;
+        settings.setValue(enabledKey, enabled.toBool());
+
+        QString pos = settings.value(SL(Position), SL(Right)).toString();
+        QString place = settings.value(SL(Placement), SL(Header)).toString();
+        if (pos != SL(Left) && pos != SL(Right))
+            pos = SL(Right);
+        if (place != SL(Header) && place != SL(Footer))
+            place = SL(Header);
+        settings.setValue(SL(Position), pos);
+        settings.setValue(SL(Placement), place);
+
+        if (g == SL(Battery)) {
+            QString type = settings.value(SL(BatteryType), SL(Level)).toString();
+            if (type != SL(Level) && type != SL(Icon) && type != SL(Both))
+                type = SL(Level);
+            settings.setValue(SL(BatteryType), type);
+        }
+
+        settings.endGroup();
+    }
+    
+    QString marginStr = settings.value(SL(Margin), SL(Auto)).toString();
+    if (marginStr != SL(Auto)) {
+        bool ok = false;
+        int margin = marginStr.toInt(&ok);
+        if (!ok || margin > maxHMargin || margin < 0 ) {
+            marginStr = SL(Auto);
+        } else {
+            marginStr = QString::number(margin);
+        }
+    }
+    settings.setValue(SL(Margin), marginStr);
+
+    QString order = settings.value(SL(WidgetOrder), SL(ClockFirst)).toString();
+    if (order != SL(ClockFirst) && order != SL(BatteryFirst))
+        order = SL(ClockFirst);
+    settings.setValue(SL(WidgetOrder), order);
+
+    settings.sync();
+}
+
+Position NCSettings::clockPosition() { return position(SL(Clock)); }
+Position NCSettings::batteryPosition() { return position(SL(Battery)); }
+Placement NCSettings::clockPlacement() { return placement(SL(Clock)); }
+Placement NCSettings::batteryPlacement() { return placement(SL(Battery)); }
+
+Position NCSettings::position(QString const& group)
+{
+    QString key = QStringLiteral("%1/%2").arg(group).arg(SL(Position));
+    QString pos = settings.value(key).toString();
+    return pos == SL(Left) ? Left : Right;
+}
+
+Placement NCSettings::placement(QString const& group)
+{
+    QString key = QStringLiteral("%1/%2").arg(group).arg(SL(Placement));
+    QString place = settings.value(key).toString();
+    return place == SL(Header) ? Header : Footer;
+}
+
+int NCSettings::margin()
+{
+    bool ok = false;
+    int margin = Auto;
+    QString marginStr = settings.value(SL(Margin)).toString();
+    if (marginStr != SL(Auto)) {
+        margin = marginStr.toInt(&ok);
+    }
+    return ok ? margin : Auto;
+}
+
+void NCSettings::setMaxHMargin(QRect const& screenGeom)
+{
+    int w = screenGeom.width() < screenGeom.height() ? screenGeom.width()
+                                                     : screenGeom.height();
+    maxHMargin = w / 4;
+}
+

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -56,6 +56,11 @@ void NCSettings::syncSettings()
             if (type != SL(Level) && type != SL(Icon) && type != SL(Both))
                 type = SL(Level);
             settings.setValue(SL(BatteryType), type);
+
+            QString label = settings.value(batteryLabelKey, QSL("%1%")).toString();
+            if (!label.contains("%1")) 
+                label = QSL("%1%");
+            settings.setValue(batteryLabelKey, label);
         }
 
         settings.endGroup();
@@ -120,6 +125,11 @@ BatteryType NCSettings::batteryType()
     QString type = settings.value(key).toString();
     return type == SL(Both) ? Both
                             : type == SL(Level) ? Level : Icon;
+}
+
+QString NCSettings::batteryLabel()
+{
+    return settings.value(QSL("%1/%2").arg(SL(Battery)).arg(batteryLabelKey)).toString();
 }
 
 int NCSettings::margin()

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -85,16 +85,33 @@ Placement NCSettings::batteryPlacement() { return placement(SL(Battery)); }
 
 Position NCSettings::position(QString const& group)
 {
-    QString key = QStringLiteral("%1/%2").arg(group).arg(SL(Position));
+    QString key = QSL("%1/%2").arg(group).arg(SL(Position));
     QString pos = settings.value(key).toString();
     return pos == SL(Left) ? Left : Right;
 }
 
 Placement NCSettings::placement(QString const& group)
 {
-    QString key = QStringLiteral("%1/%2").arg(group).arg(SL(Placement));
+    QString key = QSL("%1/%2").arg(group).arg(SL(Placement));
     QString place = settings.value(key).toString();
     return place == SL(Header) ? Header : Footer;
+}
+
+bool NCSettings::clockEnabled() { return groupEnabled(SL(Clock)); }
+bool NCSettings::batteryEnabled() { return groupEnabled(SL(Battery)); }
+
+bool NCSettings::groupEnabled(QString const& group)
+{
+    QString key = QSL("%1/%2").arg(group).arg(enabledKey);
+    return settings.value(key).toBool();
+}
+
+BatteryType NCSettings::batteryType()
+{
+    QString key = QSL("%1/%2").arg(SL(Battery)).arg(SL(BatteryType));
+    QString type = settings.value(key).toString();
+    return type == SL(Both) ? Both
+                            : type == SL(Level) ? Level : Icon;
 }
 
 int NCSettings::margin()

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -32,6 +32,9 @@ void NCSettings::syncSettings()
     }
     
     for (auto& g : {SL(Clock), SL(Battery)}) {
+        if (g == SL(Battery)) {
+            defPos = SL(Left);
+        }
         settings.beginGroup(g);
 
         QVariant enabled = settings.value(enabledKey);

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -70,11 +70,6 @@ void NCSettings::syncSettings()
     }
     settings.setValue(SL(Margin), marginStr);
 
-    QString order = settings.value(SL(WidgetOrder), SL(ClockFirst)).toString();
-    if (order != SL(ClockFirst) && order != SL(BatteryFirst))
-        order = SL(ClockFirst);
-    settings.setValue(SL(WidgetOrder), order);
-
     settings.sync();
 }
 
@@ -82,6 +77,16 @@ Position NCSettings::clockPosition() { return position(SL(Clock)); }
 Position NCSettings::batteryPosition() { return position(SL(Battery)); }
 Placement NCSettings::clockPlacement() { return placement(SL(Clock)); }
 Placement NCSettings::batteryPlacement() { return placement(SL(Battery)); }
+
+bool NCSettings::clockInPlacement(Placement const p)
+{
+    return clockEnabled() && clockPlacement() == p;
+}
+
+bool NCSettings::batteryInPlacement(Placement const p)
+{
+    return batteryEnabled() && batteryPlacement() == p;
+}
 
 Position NCSettings::position(QString const& group)
 {

--- a/src/nc_settings.cc
+++ b/src/nc_settings.cc
@@ -12,8 +12,26 @@ void NCSettings::syncSettings()
 {
     settings.sync();
 
-    QString const groups[] = {SL(Clock), SL(Battery)};
-    for (auto& g : groups) {
+    // import legacy settings
+    QString lMargin = settings.value("hor_margin").toString();
+    QString lPos = settings.value("position").toString();
+    QString lPlace = settings.value("placement").toString();
+
+    QString defPos = SL(Right);
+    QString defPlace = SL(Header);
+    QString defMargin = SL(Auto);
+    if (lPos == "left")
+        defPos = SL(Left);
+    if (lPlace == "footer")
+        defPlace == SL(Footer);
+    if (lMargin != "auto")
+        defMargin = lMargin;
+    
+    for (auto& k : {QSL("hor_margin"), QSL("position"), QSL("placement")}) {
+        settings.remove(k);
+    }
+    
+    for (auto& g : {SL(Clock), SL(Battery)}) {
         settings.beginGroup(g);
 
         QVariant enabled = settings.value(enabledKey);
@@ -21,8 +39,8 @@ void NCSettings::syncSettings()
             enabled = g == SL(Clock) ? true : false;
         settings.setValue(enabledKey, enabled.toBool());
 
-        QString pos = settings.value(SL(Position), SL(Right)).toString();
-        QString place = settings.value(SL(Placement), SL(Header)).toString();
+        QString pos = settings.value(SL(Position), defPos).toString();
+        QString place = settings.value(SL(Placement), defPlace).toString();
         if (pos != SL(Left) && pos != SL(Right))
             pos = SL(Right);
         if (place != SL(Header) && place != SL(Footer))
@@ -40,7 +58,7 @@ void NCSettings::syncSettings()
         settings.endGroup();
     }
     
-    QString marginStr = settings.value(SL(Margin), SL(Auto)).toString();
+    QString marginStr = settings.value(SL(Margin), defMargin).toString();
     if (marginStr != SL(Auto)) {
         bool ok = false;
         int margin = marginStr.toInt(&ok);

--- a/src/nc_settings.h
+++ b/src/nc_settings.h
@@ -5,8 +5,8 @@
 #include <QSettings>
 #include <QString>
 
-#define STR(s) #s
-#define SL(s) QStringLiteral(#s)
+#define QSL(s) QStringLiteral(s)
+#define SL(s) QSL(#s)
 
 class NCSettings
 {

--- a/src/nc_settings.h
+++ b/src/nc_settings.h
@@ -24,12 +24,14 @@ class NCSettings
         bool clockInPlacement(Placement const p);
         bool batteryInPlacement(Placement const p);
         BatteryType batteryType();
+        QString batteryLabel();
         int margin();
 
     private:
         QSettings settings;
         int maxHMargin = 200;
         QString enabledKey = "Enabled";
+        QString batteryLabelKey = "LevelTemplate";
 
         void setMaxHMargin(QRect const& screenGeom);
         Position position(QString const& group);

--- a/src/nc_settings.h
+++ b/src/nc_settings.h
@@ -14,10 +14,14 @@ class NCSettings
         NCSettings(QRect const& screenGeom);
 
         void syncSettings();
+
+        bool clockEnabled();
+        bool batteryEnabled();
         Position clockPosition();
         Position batteryPosition();
         Placement clockPlacement();
         Placement batteryPlacement();
+        BatteryType batteryType();
         int margin();
 
     private:
@@ -28,6 +32,7 @@ class NCSettings
         void setMaxHMargin(QRect const& screenGeom);
         Position position(QString const& group);
         Placement placement(QString const& group);
+        bool groupEnabled(QString const& group);
 };
 
 #endif // NC_SETTINGS_H

--- a/src/nc_settings.h
+++ b/src/nc_settings.h
@@ -21,6 +21,8 @@ class NCSettings
         Position batteryPosition();
         Placement clockPlacement();
         Placement batteryPlacement();
+        bool clockInPlacement(Placement const p);
+        bool batteryInPlacement(Placement const p);
         BatteryType batteryType();
         int margin();
 

--- a/src/nc_settings.h
+++ b/src/nc_settings.h
@@ -1,0 +1,33 @@
+#ifndef NC_SETTINGS_H
+#define NC_SETTINGS_H
+
+#include <QRect>
+#include <QSettings>
+#include <QString>
+
+#define STR(s) #s
+#define SL(s) QStringLiteral(#s)
+
+class NCSettings
+{
+    public:
+        NCSettings(QRect const& screenGeom);
+
+        void syncSettings();
+        Position clockPosition();
+        Position batteryPosition();
+        Placement clockPlacement();
+        Placement batteryPlacement();
+        int margin();
+
+    private:
+        QSettings settings;
+        int maxHMargin = 200;
+        QString enabledKey = "Enabled";
+
+        void setMaxHMargin(QRect const& screenGeom);
+        Position position(QString const& group);
+        Placement placement(QString const& group);
+};
+
+#endif // NC_SETTINGS_H

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -266,10 +266,12 @@ QWidget* NC::createBatteryWidget()
 int NC::getBatteryLevel()
 {
     int battery = 100;
+    if (batteryCapFilename.isEmpty())
+        batteryCapFilename = QFile::exists(nc_sysfs_gen_bat_cap)
+                              ? nc_sysfs_gen_bat_cap
+                              : nc_sysfs_mc13892_bat_cap;
     QFile bcFile;
-    bcFile.setFileName(QFile::exists(nc_sysfs_gen_bat_cap) 
-                        ? nc_sysfs_gen_bat_cap
-                        : nc_sysfs_mc13892_bat_cap);
+    bcFile.setFileName(batteryCapFilename);
     if (bcFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         bool ok = false;
         battery = bcFile.readAll().trimmed().toInt(&ok);

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -256,6 +256,7 @@ QWidget* NC::createBatteryWidget()
 
     l->setContentsMargins(0, 0, 0, 0);
     battery->setLayout(l);
+    battery->setStyleSheet("padding: 0px; margin: 0px; background-color: transparent;");
     battery->show();
     return battery;
 }

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -97,6 +97,16 @@ NickelHook(
     .uninstall = &nc_uninstall
 )
 
+// Older firmware versions have [newHeader=true] and [newFooter=true] as 
+// part of their QSS selector. Create and set those properties here.
+static void set_extra_props(QWidget* w) {
+    if (w) {
+        for (auto prop : {"newHeader", "newFooter"}) {
+            w->setProperty(prop, true);
+        }
+    }
+}
+
 NC::NC(QRect const& screenGeom) 
             : QObject(nullptr), 
               settings(screenGeom),
@@ -229,6 +239,7 @@ TimeLabel* NC::createTimeLabel()
     tl->setObjectName(nc_widget_name);
     auto hAlign = settings.clockPosition() == Left ? Qt::AlignLeft : Qt::AlignRight;
     tl->setAlignment(hAlign | Qt::AlignVCenter);
+    set_extra_props(tl);
     tl->setStyleSheet(ncLabelStylesheet());
     return tl;
 }
@@ -288,10 +299,7 @@ NCBatteryLabel::NCBatteryLabel(int initLevel, QString const& lbl, QWidget *paren
 {
     setBatteryLevel(initLevel);
     setObjectName(nc_widget_name);
-    // Older firmware versions have [newHeader=true] and [newFooter=true] as 
-    // part of their QSS selector. Create and set those properties here.
-    setProperty("newHeader", true);
-    setProperty("newFooter", true);
+    set_extra_props(this);
     HardwareInterface *hw = HardwareFactory__sharedInstance();
     if (!connect(hw, SIGNAL(battery_level(int)), this, SLOT(setBatteryLevel(int))))
         nh_log("Failed to connect battery_level signal to label");

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -243,7 +243,7 @@ QWidget* NC::createBatteryWidget()
 
     if (type == Level || type == Both) {
         int initLevel = getBatteryLevel();
-        level = new NCBatteryLabel(initLevel);
+        level = new NCBatteryLabel(initLevel, settings.batteryLabel());
         level->setStyleSheet(ncLabelStylesheet());
         l->addWidget(level, 0, Qt::AlignVCenter);
     }
@@ -281,7 +281,8 @@ int NC::getBatteryLevel()
     return battery;
 }
 
-NCBatteryLabel::NCBatteryLabel(int initLevel, QWidget *parent) : QLabel(parent)
+NCBatteryLabel::NCBatteryLabel(int initLevel, QString const& lbl, QWidget *parent) 
+    : QLabel(parent), label(lbl)
 {
     setBatteryLevel(initLevel);
     setObjectName(nc_widget_name);
@@ -289,12 +290,11 @@ NCBatteryLabel::NCBatteryLabel(int initLevel, QWidget *parent) : QLabel(parent)
     HardwareInterface *hw = HardwareFactory__sharedInstance();
     if (!connect(hw, SIGNAL(battery_level(int)), this, SLOT(setBatteryLevel(int))))
         nh_log("Failed to connect battery_level signal to label");
-    //show();
 }
 
 void NCBatteryLabel::setBatteryLevel(int level)
 {
-    QString txt = QString::number(level) + "%";
+    QString txt = label.arg(level);
     setText(txt);
 }
 

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -288,7 +288,10 @@ NCBatteryLabel::NCBatteryLabel(int initLevel, QString const& lbl, QWidget *paren
 {
     setBatteryLevel(initLevel);
     setObjectName(nc_widget_name);
-
+    // Older firmware versions have [newHeader=true] and [newFooter=true] as 
+    // part of their QSS selector. Create and set those properties here.
+    setProperty("newHeader", true);
+    setProperty("newFooter", true);
     HardwareInterface *hw = HardwareFactory__sharedInstance();
     if (!connect(hw, SIGNAL(battery_level(int)), this, SLOT(setBatteryLevel(int))))
         nh_log("Failed to connect battery_level signal to label");

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -33,6 +33,7 @@ class NC : public QObject
         QString origFooterStylesheet;
         QString ncLblStylesheet;
         QRegularExpression footerMarginRe;
+        QString batteryCapFilename;
         void updateFooterMargins(QLayout *layout);
         void getFooterStylesheet();
         void createNCLabelStylesheet();

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -45,9 +45,11 @@ class NCBatteryLabel : public QLabel
 {
     Q_OBJECT
     public:
-        NCBatteryLabel(int initLevel, QWidget *parent = nullptr);
+        NCBatteryLabel(int initLevel, QString const& label, QWidget *parent = nullptr);
     public Q_SLOTS:
         void setBatteryLevel(int level);
+    private:
+        QString label;
 };
 
 #endif

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -6,14 +6,17 @@
 #include <QLabel>
 #include <QRegularExpression>
 #include <QString>
+#include <QFrame>
 
 #include "nc_common.h"
 #include "nc_settings.h"
 
+typedef QObject HardwareInterface;
 typedef QWidget ReadingView;
 typedef QWidget ReadingFooter;
 typedef QLabel TimeLabel;
 typedef QLabel TouchLabel;
+typedef QLabel N3BatteryStatusLabel;
 
 class NC : public QObject
 {
@@ -33,7 +36,18 @@ class NC : public QObject
         void updateFooterMargins(QLayout *layout);
         void getFooterStylesheet();
         void createNCLabelStylesheet();
+        QFrame* createBatteryWidget();
         TimeLabel* createTimeLabel();
+        int getBatteryLevel();
+};
+
+class NCBatteryLabel : public QLabel
+{
+    Q_OBJECT
+    public:
+        NCBatteryLabel(QWidget *parent = nullptr);
+    public Q_SLOTS:
+        void setBatteryLevel(int level);
 };
 
 #endif

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -22,17 +22,18 @@ class NC : public QObject
         NCSettings settings;
         
         NC(QRect const& screenGeom);
-        void addTimeToFooter(ReadingFooter *rf, Position position);
+        void addItemsToFooter(ReadingView *rv);
         void setFooterStylesheet(ReadingFooter *rf);
-        QString const& timeLabelStylesheet();
+        QString const& ncLabelStylesheet();
     private:
         int origFooterMargin = -1;
         QString origFooterStylesheet;
-        QString tlStylesheet;
+        QString ncLblStylesheet;
         QRegularExpression footerMarginRe;
         void updateFooterMargins(QLayout *layout);
         void getFooterStylesheet();
-        void createTimeLabelStylesheet();
+        void createNCLabelStylesheet();
+        TimeLabel* createTimeLabel();
 };
 
 #endif

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -6,44 +6,14 @@
 #include <QLabel>
 #include <QRegularExpression>
 #include <QString>
-#include <QSettings>
+
+#include "nc_common.h"
+#include "nc_settings.h"
 
 typedef QWidget ReadingView;
 typedef QWidget ReadingFooter;
 typedef QLabel TimeLabel;
 typedef QLabel TouchLabel;
-
-enum class TimePos {Left, Right};
-enum class TimePlacement {Header, Footer};
-
-#ifndef NICKEL_CLOCK_DIR
-    #define NICKEL_CLOCK_DIR "/mnt/onboard/.adds/nickelclock"
-#endif
-
-class NCSettings 
-{
-    public:
-        NCSettings(QRect const& screenGeom);
-        
-        TimePlacement placement();
-        TimePos position();
-        int hMargin();
-    private:
-        QSettings settings;
-        QString placeKey = "placement";
-        QString posKey = "position";
-        QString marginKey = "hor_margin";
-        QString placeHeader = "header";
-        QString placeFooter = "footer";
-        QString posLeft = "left";
-        QString posRight = "right";
-        QString marginAuto = "auto";
-
-        int maxHMargin = 200;
-
-        void syncSettings();
-        void setMaxHMargin(QRect const& screenGeom);
-};
 
 class NC : public QObject
 {
@@ -52,7 +22,7 @@ class NC : public QObject
         NCSettings settings;
         
         NC(QRect const& screenGeom);
-        void addTimeToFooter(ReadingFooter *rf, TimePos position);
+        void addTimeToFooter(ReadingFooter *rf, Position position);
         void setFooterStylesheet(ReadingFooter *rf);
         QString const& timeLabelStylesheet();
     private:

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -36,7 +36,7 @@ class NC : public QObject
         void updateFooterMargins(QLayout *layout);
         void getFooterStylesheet();
         void createNCLabelStylesheet();
-        QFrame* createBatteryWidget();
+        QWidget* createBatteryWidget();
         TimeLabel* createTimeLabel();
         int getBatteryLevel();
 };
@@ -45,7 +45,7 @@ class NCBatteryLabel : public QLabel
 {
     Q_OBJECT
     public:
-        NCBatteryLabel(QWidget *parent = nullptr);
+        NCBatteryLabel(int initLevel, QWidget *parent = nullptr);
     public Q_SLOTS:
         void setBatteryLevel(int level);
 };


### PR DESCRIPTION
This PR adds support for displaying the current battery level. This can either be a label with a user defined template, the battery icon, or both together.

Current limitations are that you can not have both the clock and battery level in same placement and position. I tried to allow that, but was causing issues.

The battery icon does not display properly in dark mode, there doesn't appear to be an inverted version of the icon.

When displaying both level and icon together, there is a fairly large gap between them. I haven't managed to reduce that gap.

The settings file format has changed a lot, if you just want to test, take a backup of the old settings, as they are migrated then deleted.