### PR TITLE
Implement own battery icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ compile_commands.json
 /libnickelclock.so
 /src/nickelclock.o
 /src/nc_settings.o
+/src/nc_battery.o
 /src/nickelclock.moc
+/src/nc_battery.moc
 /src/nickelclock.moc.o
+/src/nc_battery.moc.o

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 include libs/NickelHook/NickelHook.mk
 
 override LIBRARY  := libnickelclock.so
-override SOURCES  += src/nickelclock.cc src/nc_settings.cc 
-override MOCS     += src/nickelclock.h
+override SOURCES  += src/nickelclock.cc src/nc_settings.cc src/nc_battery.cc
+override MOCS     += src/nickelclock.h src/nc_battery.h
 override CFLAGS   += -Wall -Wextra -Werror
 override CXXFLAGS += -Wall -Wextra -Werror -Wno-missing-field-initializers
 

--- a/src/nc_battery.cc
+++ b/src/nc_battery.cc
@@ -63,11 +63,11 @@ static int get_battery_level_index(int level)
 
 NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f, QWidget *parent)
     : QFrame(parent),
+      hwi(nullptr),
       text_label(nullptr),
       icon(nullptr),
       text_fmt(text_f),
       battery_level(0),
-      curr_index(0),
       is_charging(false),
       dark_mode_enabled(false),
       dark_mode_changed(false)
@@ -85,7 +85,9 @@ NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f
     this->setLayout(layout);
     this->setStyleSheet("padding: 0px; margin: 0px; background-color: transparent;");
 
-    auto hwi = HardwareFactory__sharedInstance();
+    hwi = HardwareFactory__sharedInstance();
+    battery_level_fn = get_derived_hw_interface_method<decltype(battery_level_fn)>(HardwareInterface__getBatteryLevel, hwi);
+    charging_state_fn = get_derived_hw_interface_method<decltype(charging_state_fn)>(HardwareInterface__chargingState, hwi);
 
     QObject::connect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
 
@@ -102,8 +104,6 @@ NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f
 
 NCBatteryLabel::~NCBatteryLabel()
 {
-    auto hwi = HardwareFactory__sharedInstance();
-
     QObject::disconnect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
 
     QObject::disconnect(hwi, SIGNAL(battery_changed()), this, SLOT(updateBattery()));
@@ -124,10 +124,6 @@ void NCBatteryLabel::onBatteryLevel(int level)
 
 void NCBatteryLabel::updateBattery()
 {
-    auto hwi = HardwareFactory__sharedInstance();
-    auto battery_level_fn = get_derived_hw_interface_method<int (*)(HardwareInterface* self)>(HardwareInterface__getBatteryLevel, hwi);
-    auto charging_state_fn = get_derived_hw_interface_method<uint (*)(HardwareInterface* self)>(HardwareInterface__chargingState, hwi);
-
     int bl = battery_level_fn(hwi);
     bool charging = static_cast<bool>(charging_state_fn(hwi));
 
@@ -148,10 +144,11 @@ void NCBatteryLabel::onDarkModeChanged(bool enabled)
 
 QString NCBatteryLabel::batteryIconPathName()
 {
+    int index = get_battery_level_index(battery_level);
     if (is_charging) {
-        return QStringLiteral(":/images/statusbar/battery_charging_%1.png").arg(curr_index, 2, 10, QLatin1Char('0'));
+        return QStringLiteral(":/images/statusbar/battery_charging_%1.png").arg(index, 2, 10, QLatin1Char('0'));
     } else {
-        return QStringLiteral(":/images/statusbar/battery_%1.png").arg(curr_index, 2, 10, QLatin1Char('0'));
+        return QStringLiteral(":/images/statusbar/battery_%1.png").arg(index, 2, 10, QLatin1Char('0'));
     }
     return QString();
 }
@@ -162,14 +159,19 @@ void NCBatteryLabel::setLabels()
         text_label->setText(text_fmt.arg(battery_level));
     }
     if (icon) {
-        curr_index = get_battery_level_index(battery_level);
-        QImage icon_png(batteryIconPathName());
-        if (dark_mode_enabled) {
-            icon_png.invertPixels(QImage::InvertRgb);
+        QString icon_path = batteryIconPathName();
+        QString icon_key = dark_mode_enabled ? icon_path + ".inverted" : icon_path;
+
+        if (!icon_cache.contains(icon_key)) {
+            QImage icon_png(icon_path);
+            if (dark_mode_enabled) {
+                icon_png.invertPixels(QImage::InvertRgb);
+            }
+            // The battery icons have quite a large border, so crop to opaque area
+            QPixmap icon_px = QPixmap::fromImage(icon_png);
+            auto bb = QRegion(icon_px.mask()).boundingRect();
+            icon_cache.insert(icon_key, icon_px.copy(bb));
         }
-        // The battery icons have quite a large border, so crop to opaque area
-        QPixmap icon_px = QPixmap::fromImage(icon_png);
-        auto bb = QRegion(icon_px.mask()).boundingRect();
-        icon->setPixmap(icon_px.copy(bb));
+        icon->setPixmap(icon_cache.value(icon_key));
     }
 }

--- a/src/nc_battery.cc
+++ b/src/nc_battery.cc
@@ -66,18 +66,12 @@ NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f
       text_label(nullptr),
       icon(nullptr),
       text_fmt(text_f),
+      battery_level(0),
+      curr_index(0),
       is_charging(false),
-      dark_mode_enabled(false)
+      dark_mode_enabled(false),
+      dark_mode_changed(false)
 {
-    auto hwi = HardwareFactory__sharedInstance();
-    auto battery_level_fn = get_derived_hw_interface_method<int (*)(HardwareInterface* self)>(HardwareInterface__getBatteryLevel, hwi);
-    auto charging_state_fn = get_derived_hw_interface_method<uint (*)(HardwareInterface* self)>(HardwareInterface__chargingState, hwi);
-
-    battery_level = battery_level_fn(hwi);
-    curr_index = get_battery_level_index(battery_level);
-
-    is_charging = static_cast<bool>(charging_state_fn(hwi));
-
     QHBoxLayout* layout = new QHBoxLayout();
     if (text_en) {
         text_label = new QLabel();
@@ -91,15 +85,19 @@ NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f
     this->setLayout(layout);
     this->setStyleSheet("padding: 0px; margin: 0px; background-color: transparent;");
 
-    setLabels();
+    auto hwi = HardwareFactory__sharedInstance();
 
     QObject::connect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
 
-    QObject::connect(hwi, SIGNAL(usb_plugged()), this, SLOT(onUsbPlugged()));
-    QObject::connect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(onUsbPlugged()));
+    QObject::connect(hwi, SIGNAL(battery_changed()), this, SLOT(updateBattery()));
 
-    QObject::connect(hwi, SIGNAL(usb_unplugged()), this, SLOT(onUsbUnplugged()));
-    QObject::connect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(onUsbUnplugged()));
+    QObject::connect(hwi, SIGNAL(usb_plugged()), this, SLOT(updateBattery()));
+    QObject::connect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(updateBattery()));
+
+    QObject::connect(hwi, SIGNAL(usb_unplugged()), this, SLOT(updateBattery()));
+    QObject::connect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(updateBattery()));
+
+    updateBattery();
 }
 
 NCBatteryLabel::~NCBatteryLabel()
@@ -108,33 +106,34 @@ NCBatteryLabel::~NCBatteryLabel()
 
     QObject::disconnect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
 
-    QObject::disconnect(hwi, SIGNAL(usb_plugged()), this, SLOT(onUsbPlugged()));
-    QObject::disconnect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(onUsbPlugged()));
+    QObject::disconnect(hwi, SIGNAL(battery_changed()), this, SLOT(updateBattery()));
 
-    QObject::disconnect(hwi, SIGNAL(usb_unplugged()), this, SLOT(onUsbUnplugged()));
-    QObject::disconnect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(onUsbUnplugged()));
+    QObject::disconnect(hwi, SIGNAL(usb_plugged()), this, SLOT(updateBattery()));
+    QObject::disconnect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(updateBattery()));
+
+    QObject::disconnect(hwi, SIGNAL(usb_unplugged()), this, SLOT(updateBattery()));
+    QObject::disconnect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(updateBattery()));
 }
 
 
 void NCBatteryLabel::onBatteryLevel(int level)
 {
-    if (level != battery_level) {
-        setLabels();
-    }
+    (void)level;
+    updateBattery();
 }
 
-void NCBatteryLabel::onUsbPlugged()
+void NCBatteryLabel::updateBattery()
 {
-    if (!is_charging) {
-        is_charging = true;
-        setLabels();
-    }
-}
+    auto hwi = HardwareFactory__sharedInstance();
+    auto battery_level_fn = get_derived_hw_interface_method<int (*)(HardwareInterface* self)>(HardwareInterface__getBatteryLevel, hwi);
+    auto charging_state_fn = get_derived_hw_interface_method<uint (*)(HardwareInterface* self)>(HardwareInterface__chargingState, hwi);
 
-void NCBatteryLabel::onUsbUnplugged()
-{
-    if (is_charging) {
-        is_charging = false;
+    int bl = battery_level_fn(hwi);
+    bool charging = static_cast<bool>(charging_state_fn(hwi));
+
+    if (bl != battery_level || charging != is_charging || dark_mode_changed) {
+        battery_level = bl;
+        is_charging = charging;
         setLabels();
     }
 }
@@ -142,7 +141,9 @@ void NCBatteryLabel::onUsbUnplugged()
 void NCBatteryLabel::onDarkModeChanged(bool enabled)
 {
     dark_mode_enabled = enabled;
-    setLabels();
+    dark_mode_changed = true;
+    updateBattery();
+    dark_mode_changed = false;
 }
 
 QString NCBatteryLabel::batteryIconPathName()
@@ -161,6 +162,7 @@ void NCBatteryLabel::setLabels()
         text_label->setText(text_fmt.arg(battery_level));
     }
     if (icon) {
+        curr_index = get_battery_level_index(battery_level);
         QImage icon_png(batteryIconPathName());
         if (dark_mode_enabled) {
             icon_png.invertPixels(QImage::InvertRgb);

--- a/src/nc_battery.cc
+++ b/src/nc_battery.cc
@@ -1,0 +1,173 @@
+#include <cmath>
+
+#include <QPaintEvent>
+#include <QHBoxLayout>
+#include <QImage>
+#include <QBitmap>
+
+#include "nc_battery.h"
+
+HardwareInterface *(*HardwareFactory__sharedInstance)() = nullptr;
+
+uintptr_t** HardwareInterface__vtable = nullptr;
+int  (*HardwareInterface__getBatteryLevel)(HardwareInterface* self) = nullptr;
+uint (*HardwareInterface__chargingState)(HardwareInterface* self) = nullptr;
+
+// I took this from my PR for kobo-tweaks. See:
+// https://github.com/redphx/kobo-tweaks/pull/11
+template <typename F>
+static F get_derived_hw_interface_method(F HWInterfaceFunc, HardwareInterface* hw)
+{
+    struct VPtr {
+        uintptr_t** v;
+    };
+    if (!HWInterfaceFunc) {
+        return nullptr;
+    }
+    // The list of method pointers starts from the third entry
+    // in the vtable (this is what the class vptr variable points to)
+    uintptr_t** hwiVtr = HardwareInterface__vtable + 2;
+    
+    // Search the HardwareInterface vtable for the offset to the method 
+    // we want to call on the derived object. 
+    // Iterate at least 8 times, because the vtable has a null pointer
+    // at the destructor offset (4).
+    for (int offset = 0; offset < 8 || hwiVtr[offset] != nullptr; ++offset) {
+        uintptr_t* f = hwiVtr[offset];
+
+        // Method found at this offset
+        // Return the method at this offset in the derived vtable
+        if (f == reinterpret_cast<uintptr_t*>(HWInterfaceFunc)) {
+            auto derivedVptr = reinterpret_cast<VPtr*>(hw);
+            return reinterpret_cast<F>(derivedVptr->v[offset]);
+        }
+    }
+    return nullptr;
+}
+
+// Choose from one of the 20 battery level icons in the firmware based
+// on the provided battery level. Uses the same algorithm as used by
+// GenericBatteryStatusLabel::getBatteryPixmapIndex
+static int get_battery_level_index(int level)
+{
+    double l = static_cast<double>(level);
+    if (l > 100.0f) {
+        l = 100.0f;
+    } else if (l < 1.0f) {
+        l = 1.0f;
+    }
+
+    double index = std::ceil((l / 100.00f) * 20.00f); 
+    return static_cast<int>(index);
+}
+
+NCBatteryLabel::NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f, QWidget *parent)
+    : QFrame(parent),
+      text_label(nullptr),
+      icon(nullptr),
+      text_fmt(text_f),
+      is_charging(false),
+      dark_mode_enabled(false)
+{
+    auto hwi = HardwareFactory__sharedInstance();
+    auto battery_level_fn = get_derived_hw_interface_method<int (*)(HardwareInterface* self)>(HardwareInterface__getBatteryLevel, hwi);
+    auto charging_state_fn = get_derived_hw_interface_method<uint (*)(HardwareInterface* self)>(HardwareInterface__chargingState, hwi);
+
+    battery_level = battery_level_fn(hwi);
+    curr_index = get_battery_level_index(battery_level);
+
+    is_charging = static_cast<bool>(charging_state_fn(hwi));
+
+    QHBoxLayout* layout = new QHBoxLayout();
+    if (text_en) {
+        text_label = new QLabel();
+        layout->addWidget(text_label);
+    }
+    if (icon_en) {
+        icon = new QLabel();
+        layout->addWidget(icon);
+    }
+    layout->setContentsMargins(0, 0, 0, 0);
+    this->setLayout(layout);
+    this->setStyleSheet("padding: 0px; margin: 0px; background-color: transparent;");
+
+    setLabels();
+
+    QObject::connect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
+
+    QObject::connect(hwi, SIGNAL(usb_plugged()), this, SLOT(onUsbPlugged()));
+    QObject::connect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(onUsbPlugged()));
+
+    QObject::connect(hwi, SIGNAL(usb_unplugged()), this, SLOT(onUsbUnplugged()));
+    QObject::connect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(onUsbUnplugged()));
+}
+
+NCBatteryLabel::~NCBatteryLabel()
+{
+    auto hwi = HardwareFactory__sharedInstance();
+
+    QObject::disconnect(hwi, SIGNAL(battery_level(int)), this, SLOT(onBatteryLevel(int)));
+
+    QObject::disconnect(hwi, SIGNAL(usb_plugged()), this, SLOT(onUsbPlugged()));
+    QObject::disconnect(hwi, SIGNAL(usb_ac_plugged()), this, SLOT(onUsbPlugged()));
+
+    QObject::disconnect(hwi, SIGNAL(usb_unplugged()), this, SLOT(onUsbUnplugged()));
+    QObject::disconnect(hwi, SIGNAL(usb_ac_unplugged()), this, SLOT(onUsbUnplugged()));
+}
+
+
+void NCBatteryLabel::onBatteryLevel(int level)
+{
+    if (level != battery_level) {
+        setLabels();
+    }
+}
+
+void NCBatteryLabel::onUsbPlugged()
+{
+    if (!is_charging) {
+        is_charging = true;
+        setLabels();
+    }
+}
+
+void NCBatteryLabel::onUsbUnplugged()
+{
+    if (is_charging) {
+        is_charging = false;
+        setLabels();
+    }
+}
+
+void NCBatteryLabel::onDarkModeChanged(bool enabled)
+{
+    dark_mode_enabled = enabled;
+    setLabels();
+}
+
+QString NCBatteryLabel::batteryIconPathName()
+{
+    if (is_charging) {
+        return QStringLiteral(":/images/statusbar/battery_charging_%1.png").arg(curr_index, 2, 10, QLatin1Char('0'));
+    } else {
+        return QStringLiteral(":/images/statusbar/battery_%1.png").arg(curr_index, 2, 10, QLatin1Char('0'));
+    }
+    return QString();
+}
+
+void NCBatteryLabel::setLabels()
+{
+    if (text_label) {
+        text_label->setText(text_fmt.arg(battery_level));
+    }
+    if (icon) {
+        QImage icon_png(batteryIconPathName());
+        if (dark_mode_enabled) {
+            icon_png.invertPixels(QImage::InvertRgb);
+        }
+        // The battery icons have quite a large border, so crop to opaque area
+        QPixmap icon_px = QPixmap::fromImage(icon_png);
+        auto bb = QRegion(icon_px.mask()).boundingRect();
+        icon->setPixmap(icon_px.copy(bb));
+    }
+}

--- a/src/nc_battery.h
+++ b/src/nc_battery.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QLabel>
 #include <QFrame>
+#include <QHash>
+#include <QPixmap>
 
 typedef QObject HardwareInterface;
 
@@ -32,16 +34,22 @@ private:
     QString batteryIconPathName();
     void setLabels();
 
+    int (*battery_level_fn)(HardwareInterface* self);
+    uint (*charging_state_fn)(HardwareInterface* self);
+
+    HardwareInterface* hwi;
+
     QLabel* text_label;
     QLabel* icon;
     QString text_fmt;
 
     int battery_level;
-    int curr_index;
 
     bool is_charging;
     bool dark_mode_enabled;
     bool dark_mode_changed;
+
+    QHash<QString, QPixmap> icon_cache;
 };
 
 #endif // NC_BATTERY_H

--- a/src/nc_battery.h
+++ b/src/nc_battery.h
@@ -1,0 +1,47 @@
+#ifndef NC_BATTERY_H
+#define NC_BATTERY_H
+
+#include <QObject>
+#include <QLabel>
+#include <QFrame>
+
+typedef QObject HardwareInterface;
+
+extern HardwareInterface *(*HardwareFactory__sharedInstance)();
+extern uintptr_t** HardwareInterface__vtable;
+extern int  (*HardwareInterface__getBatteryLevel)(HardwareInterface* self);
+extern uint (*HardwareInterface__chargingState)(HardwareInterface* self);
+
+class NCBatteryLabel : public QFrame
+{
+    Q_OBJECT
+
+public:
+    NCBatteryLabel(bool text_en, bool icon_en, QString const& text_f, QWidget* parent = nullptr);
+    ~NCBatteryLabel() override;
+    
+    QLabel* getLabel() { return text_label; }
+    QLabel* getIcon() { return icon; }
+
+public slots:
+    void onDarkModeChanged(bool enabled);
+    void onBatteryLevel(int level);
+    void onUsbPlugged();
+    void onUsbUnplugged();
+
+private:
+    QString batteryIconPathName();
+    void setLabels();
+
+    QLabel* text_label;
+    QLabel* icon;
+    QString text_fmt;
+
+    int battery_level;
+    int curr_index;
+
+    bool is_charging;
+    bool dark_mode_enabled;
+};
+
+#endif // NC_BATTERY_H

--- a/src/nc_battery.h
+++ b/src/nc_battery.h
@@ -26,8 +26,7 @@ public:
 public slots:
     void onDarkModeChanged(bool enabled);
     void onBatteryLevel(int level);
-    void onUsbPlugged();
-    void onUsbUnplugged();
+    void updateBattery();
 
 private:
     QString batteryIconPathName();
@@ -42,6 +41,7 @@ private:
 
     bool is_charging;
     bool dark_mode_enabled;
+    bool dark_mode_changed;
 };
 
 #endif // NC_BATTERY_H

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -20,22 +20,18 @@
 const char nc_qt_property[] = "NickelClock";
 const char nc_widget_name[] = "ncLabelWidget";
 
-const char* battery_cap_files[] = {
-    "/sys/class/power_supply/battery/capacity",
-    "/sys/class/power_supply/mc13892_bat/capacity",
-    "/sys/class/power_supply/bd71827_bat/capacity"
-};
-
 NC *nc = nullptr;
 
 // This is somewhat arbitrary, but seems a good place to get
 // access to the ReadingView after it has been created.
 void (*ReadingView__ReaderIsDoneLoading)(ReadingView *_this);
+
+// ReadingView provides a DarkModeChanged signal, but that does not provide the
+// actual value, so we need to call this method as well
+bool (*ReadingView__canEnableDarkMode)(ReadingView *_this);
+
 // TimeLabel is what the status bar uses to show the time
 TimeLabel *(*TimeLabel__TimeLabel)(TimeLabel *_this, QWidget *parent);
-
-HardwareInterface *(*HardwareFactory__sharedInstance)();
-N3BatteryStatusLabel *(*N3BatteryStatusLabel__N3BatteryStatusLabel)(N3BatteryStatusLabel* _this, QWidget *parent);
 
 static struct nh_info NickelClock = {
     .name           = "NickelClock",
@@ -68,9 +64,24 @@ static struct nh_dlsym NickelClockDlsym[] = {
         .desc    = "HardwareFactory::sharedInstance()"
     },
     {
-        .name    = "_ZN20N3BatteryStatusLabelC1EP7QWidget",
-        .out     = nh_symoutptr(N3BatteryStatusLabel__N3BatteryStatusLabel),
-        .desc    = "N3BatteryStatusLabel::N3BatteryStatusLabel()"
+        .name    = "_ZTV17HardwareInterface",
+        .out     = nh_symoutptr(HardwareInterface__vtable),
+        .desc    = "HardwareInterface::vtable"
+    },
+    {   .name    = "_ZNK17HardwareInterface15getBatteryLevelEv",
+        .out     = nh_symoutptr(HardwareInterface__getBatteryLevel),
+        .desc    = "HardwareInterface::getBatteryLevel()",
+    },
+    {
+        .name    = "_ZN17HardwareInterface13chargingStateEv",
+        .out     = nh_symoutptr(HardwareInterface__chargingState),
+        .desc    = "HardwareInterface::chargingState()",
+    },
+    {
+        .name    = "_ZN11ReadingView17canEnableDarkModeEv",
+        .out     = nh_symoutptr(ReadingView__canEnableDarkMode),
+        .desc    = "ReadingView::canEnableDarkMode()",
+        .optional= true
     },
     {0},
 };
@@ -118,6 +129,11 @@ NC::NC(QRect const& screenGeom)
 {
     getFooterStylesheet();
     createNCLabelStylesheet();
+}
+
+void NC::setReadingView(ReadingView *rv)
+{
+    readingView = rv;
 }
 
 void NC::getFooterStylesheet()
@@ -203,7 +219,7 @@ void NC::addItemsToFooter(ReadingView *rv)
             }
         }
         if (settings.batteryInPlacement(p)) {
-            QWidget *bl = createBatteryWidget();
+            NCBatteryLabel *bl = createBatteryWidget();
             if (settings.batteryPosition() == Left) {
                 layout->insertWidget(0, bl, 1, Qt::AlignLeft);
                 lw = true;
@@ -239,6 +255,13 @@ void NC::setFooterStylesheet(ReadingFooter *rf)
     rf->setStyleSheet(ss.replace(footerMarginRe, s));
 }
 
+void NC::onDarkModeChanged()
+{
+    if (ReadingView__canEnableDarkMode) {
+        emit darkModeChanged(ReadingView__canEnableDarkMode(readingView));
+    }
+}
+
 TimeLabel* NC::createTimeLabel()
 {
     TimeLabel *tl = (TimeLabel*) ::operator new (128); // Actual size 88 bytes
@@ -251,78 +274,28 @@ TimeLabel* NC::createTimeLabel()
     return tl;
 }
 
-QWidget* NC::createBatteryWidget()
+NCBatteryLabel* NC::createBatteryWidget()
 {
     BatteryType type = settings.batteryType();
-    QWidget *battery = new QWidget();
-    QHBoxLayout *l = new QHBoxLayout();
-    NCBatteryLabel *level = nullptr;
-    N3BatteryStatusLabel *icon = nullptr;
+    QString level_fmt = settings.batteryLabel();
+    bool level_enabled = (type == Level || type == Both);
+    bool icon_enabled = (type == Icon || type == Both);
+    NCBatteryLabel *battery = new NCBatteryLabel(level_enabled, icon_enabled, level_fmt);
 
-    if (type == Level || type == Both) {
-        int initLevel = getBatteryLevel();
-        level = new NCBatteryLabel(initLevel, settings.batteryLabel());
-        level->setStyleSheet(ncLabelStylesheet());
-        l->addWidget(level, 0, Qt::AlignVCenter);
-    }
-
-    if (type == Icon || type == Both) {
-        icon = (N3BatteryStatusLabel*) ::operator new (256); // Actual size 208 bytes
-        N3BatteryStatusLabel__N3BatteryStatusLabel(icon, nullptr);
-        l->addWidget(icon, 0, Qt::AlignVCenter);
-    }
-
-    l->setContentsMargins(0, 0, 0, 0);
-    battery->setLayout(l);
-    battery->setStyleSheet("padding: 0px; margin: 0px; background-color: transparent;");
-    battery->show();
-    return battery;
-}
-
-// Trying to get the battery level out of Nickel seems to be more trouble
-// than it's worth, therefore get it via sysfs
-int NC::getBatteryLevel()
-{
-    int battery = 100;
-    if (batteryCapFilename.isEmpty()) {
-        for (auto file_name : battery_cap_files) {
-            if (QFile::exists(file_name)) {
-                batteryCapFilename = file_name;
-                break;
-            }
+    auto hAlign = settings.batteryPosition() == Left ? Qt::AlignLeft : Qt::AlignRight;
+    for (auto l : {battery->getLabel(), battery->getIcon()}) {
+        if (l) {
+            l->setObjectName(nc_widget_name);
+            l->setAlignment(hAlign | Qt::AlignVCenter);
+            l->setStyleSheet(ncLabelStylesheet());
+            set_extra_props(l);
         }
     }
-    if (batteryCapFilename.isEmpty()) {
-        return battery;
-    }
-    QFile bcFile;
-    bcFile.setFileName(batteryCapFilename);
-    if (bcFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        bool ok = false;
-        battery = bcFile.readAll().trimmed().toInt(&ok);
-        if (!ok) {
-            nh_log("failed to get battery level");
-            battery = 100;
-        }
-    }
+    battery->setObjectName(nc_widget_name);
+    battery->setStyleSheet(ncLabelStylesheet());
+    set_extra_props(battery);
+    QObject::connect(this, &NC::darkModeChanged, battery, &NCBatteryLabel::onDarkModeChanged, Qt::UniqueConnection);
     return battery;
-}
-
-NCBatteryLabel::NCBatteryLabel(int initLevel, QString const& lbl, QWidget *parent) 
-    : QLabel(parent), label(lbl)
-{
-    setBatteryLevel(initLevel);
-    setObjectName(nc_widget_name);
-    set_extra_props(this);
-    HardwareInterface *hw = HardwareFactory__sharedInstance();
-    if (!connect(hw, SIGNAL(battery_level(int)), this, SLOT(setBatteryLevel(int))))
-        nh_log("Failed to connect battery_level signal to label");
-}
-
-void NCBatteryLabel::setBatteryLevel(int level)
-{
-    QString txt = label.arg(level);
-    setText(txt);
 }
 
 // On recent 4.x firmware versions, the header and footer are setup in 
@@ -331,7 +304,11 @@ void NCBatteryLabel::setBatteryLevel(int level)
 extern "C" __attribute__((visibility("default"))) void _nc_set_header_clock(ReadingView *_this) 
 {
     nc->settings.syncSettings();
+    nc->setReadingView(_this);
     nc->addItemsToFooter(_this);
+    if (!QObject::connect(_this, SIGNAL(darkModeChangedSignal()), nc, SLOT(onDarkModeChanged()), Qt::UniqueConnection)) {
+        nh_log("Connect to ReadingView::darkModeChangedSignal() failed");
+    }
     if (nc->settings.debugEnabled()) {
         nh_dump_log();
     }

--- a/src/nickelclock.h
+++ b/src/nickelclock.h
@@ -10,6 +10,7 @@
 
 #include "nc_common.h"
 #include "nc_settings.h"
+#include "nc_battery.h"
 
 typedef QObject HardwareInterface;
 typedef QWidget ReadingView;
@@ -25,9 +26,17 @@ class NC : public QObject
         NCSettings settings;
         
         NC(QRect const& screenGeom);
+        void setReadingView(ReadingView *rv);
         void addItemsToFooter(ReadingView *rv);
         void setFooterStylesheet(ReadingFooter *rf);
         QString const& ncLabelStylesheet();
+
+    public slots:
+        void onDarkModeChanged();
+
+    signals:
+        void darkModeChanged(bool enabled);
+
     private:
         int origFooterMargin = -1;
         QString origFooterStylesheet;
@@ -35,23 +44,12 @@ class NC : public QObject
         QRegularExpression footerMarginRe;
         QString batteryCapFilename;
         QRect scrGeom;
+        ReadingView *readingView;
         void updateFooterMargins(QLayout *layout);
         void getFooterStylesheet();
         void createNCLabelStylesheet();
-        QWidget* createBatteryWidget();
+        NCBatteryLabel* createBatteryWidget();
         TimeLabel* createTimeLabel();
-        int getBatteryLevel();
-};
-
-class NCBatteryLabel : public QLabel
-{
-    Q_OBJECT
-    public:
-        NCBatteryLabel(int initLevel, QString const& label, QWidget *parent = nullptr);
-    public Q_SLOTS:
-        void setBatteryLevel(int level);
-    private:
-        QString label;
 };
 
 #endif


### PR DESCRIPTION
Create a custom battery widget, which has a couple of advantages:

- The icon will work with dark mode
- The icon can be cropped to reduce the borders

@mon this PR saves the ReadingView pointer, so you might want to base your PR on this. Also, if you're willing, can you try this on your Kobo?