### PR TITLE
Fix battery icon dark mode state on initial load

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following settings may be set. **Note that entries are case sensitive**:
 |`BatteryType`|`Level`, `Icon`, `Both`|
 |`LevelTemplate`|Any string that contains `%1`|
 
-The battery icon is not compatible with dark mode, the icon is not inverted.
+The battery icon is inverted automatically when dark mode is enabled.
 
 Setting both clock and battery level to the same placement and position is 
 not supported, and the result will be neither showing.

--- a/src/nickelclock.cc
+++ b/src/nickelclock.cc
@@ -396,6 +396,7 @@ extern "C" __attribute__((visibility("default"))) void _nc_set_header_clock(Read
     if (!QObject::connect(_this, SIGNAL(darkModeChangedSignal()), nc, SLOT(onDarkModeChanged()), Qt::UniqueConnection)) {
         nh_log("Connect to ReadingView::darkModeChangedSignal() failed");
     }
+    nc->onDarkModeChanged();
     nc->reading_view = _this;
 
     SelectionController* sc = nullptr;


### PR DESCRIPTION
This fixes the initial dark mode state of the battery icon.

The current code updates the icon when `darkModeChangedSignal()` is emitted, but the initial state may be incorrect before that first event occurs. This change calls `onDarkModeChanged()` immediately after connecting the signal so the icon is initialized with the correct appearance as soon as the reading view is set up.

Changes:
- call `onDarkModeChanged()` right after connecting `darkModeChangedSignal()`
- fix the initial battery icon state before the first dark mode toggle
- update the README to reflect the actual dark mode behavior

Tested on Kobo Libra with Nikel Menu (dark mode active) by building the Kobo package from the fork and verifying the result on device.